### PR TITLE
Status Bar

### DIFF
--- a/lib/pwnstyles_rails/generators/layouts/_status_bar.html.erb
+++ b/lib/pwnstyles_rails/generators/layouts/_status_bar.html.erb
@@ -7,6 +7,20 @@
                            'data-pwnfx-reveal-trigger' => 'click-hide' %>
   </span>
 </p>
+<% elsif flash[:errors] && flash[:errors].any? %>
+<div class="status-bar error" data-pwnfx-reveal-target="status-bar">
+  <%= pluralize(flash[:errors].count, "error") %> occurred:
+  <span class="actions">
+  <%= link_to 'Hide', '#', 'data-pwnfx-reveal' => 'status-bar',
+                           'data-pwnfx-reveal-trigger' => 'click-hide' %>
+  </span>
+
+  <ul>
+  <% flash[:errors].full_messages.each do |msg| %>
+    <li><%= msg %></li>
+  <% end %>
+  </ul>
+</div>
 <% elsif flash[:notice] %>
 <p class="status-bar notice" data-pwnfx-reveal-target="status-bar">
   <%= flash[:notice] %>


### PR DESCRIPTION
Added display of errors of type ActiveRecord:Errors because all the validation errors are aggregated into this object. The current error display only handles the case where there's a simple error message.
